### PR TITLE
dart_pubspec_licenses: Add a working example

### DIFF
--- a/packages/dart_pubspec_licenses/CHANGELOG.md
+++ b/packages/dart_pubspec_licenses/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1+1
+
+* Add a standalone example and replace the example in `README.md`.
+
 ## 1.0.1
 
 * Renaming the things

--- a/packages/dart_pubspec_licenses/README.md
+++ b/packages/dart_pubspec_licenses/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-[dart_pubspec_licenses](https://pub.dev/packages/flutter_oss_licenses) is a package that helps gather and assemble OSS license info using `pubspec.lock`.
+[dart_pubspec_licenses](https://pub.dev/packages/dart_pubspec_licenses) is a package that helps gather and assemble OSS license info using `pubspec.lock`.
 
 ## Installation
 ```yaml
@@ -9,16 +9,8 @@ dependencies:
 ```
 
 ## Usage
-```dart
-import 'package:dart_pubspec_licenses/dart_pubspec_licenses.dart' as oss;
 
-void main() async {
-  final pubspecLockPath = "path/to/pubspec.lock";
-  final info = await oss.generateLicenseInfo(
-      pubspecLockPath: project.pubspecLockPath);
-  print(info);
-}
-```
+See [the example](https://pub.dev/packages/dart_pubspec_licenses/example).
 
 ## Reporting issues
 

--- a/packages/dart_pubspec_licenses/example/generate_licenses.dart
+++ b/packages/dart_pubspec_licenses/example/generate_licenses.dart
@@ -1,0 +1,42 @@
+#!/usr/bin/env dart
+
+/// A command-line tool to print license information for all direct
+/// (non-transitive and non-development) dependencies from a Dart project's
+/// `pubspec.lock` file.
+///
+/// Takes a path to the Dart project as an argument.  If no argument is
+/// specified, uses the current working directory.
+
+import 'dart:io' as io;
+import 'package:path/path.dart' as path;
+import 'package:dart_pubspec_licenses/dart_pubspec_licenses.dart' as oss;
+
+void main(List<String> args) async {
+  final projectRoot = args.isEmpty ? '.' : args.first;
+  final pubspecLockPath = path.join(projectRoot, 'pubspec.lock');
+  if (!io.File(pubspecLockPath).existsSync()) {
+    io.stderr.writeln('"$pubspecLockPath" not found.');
+    io.exitCode = 1;
+    return;
+  }
+
+  final info = await oss.generateLicenseInfo(pubspecLockPath: pubspecLockPath);
+
+  var firstIteration = true;
+  for (var entry in info.entries) {
+    if (!(entry.value['isDirectDependency'] ?? false)) {
+      continue;
+    }
+
+    if (!firstIteration) {
+      print('-' * 40);
+    }
+
+    print(
+      '${entry.key}:\n'
+      '\n'
+      '${entry.value['license']}\n',
+    );
+    firstIteration = false;
+  }
+}

--- a/packages/dart_pubspec_licenses/pubspec.yaml
+++ b/packages/dart_pubspec_licenses/pubspec.yaml
@@ -1,15 +1,15 @@
 name: dart_pubspec_licenses
 description: A library to make it easy to extract OSS license information from Dart packages using pubspec.yaml
-version: 1.0.1
+version: 1.0.1+1
 homepage: https://github.com/espresso3389/flutter_oss_licenses/tree/master/packages/dart_pubspec_licenses
 repository: https://github.com/espresso3389/flutter_oss_licenses
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
-dependencies: 
+dependencies:
   yaml: ^3.1.0
   path: ^1.8.0
 
-dev_dependencies: 
+dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
dart_pubspec_licenses' usage example in `README.md` had a couple of
problems:

* It had a typo (referring to a non-existent `project` variable).
* It printed the license information as a Dart `Map`, which would
  not be ideally formatted and which would include other package
  metadata.

Replace the example from `README.md` with a standalone command-line
app.