### PR TITLE
dart_pubspec_licenses: Make FLUTTER_ROOT optional

### DIFF
--- a/packages/dart_pubspec_licenses/CHANGELOG.md
+++ b/packages/dart_pubspec_licenses/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* Make the `FLUTTER_ROOT` environment variable optional.
+
 ## 1.0.2
 
 * Supporting git/local relative path [#7](https://github.com/espresso3389/flutter_oss_licenses/issues/7)

--- a/packages/dart_pubspec_licenses/lib/src/license_info_utils.dart
+++ b/packages/dart_pubspec_licenses/lib/src/license_info_utils.dart
@@ -37,9 +37,6 @@ Future<Map<String, dynamic>> generateLicenseInfo({required String pubspecLockPat
   if (pubCacheDir == null) {
     throw "could not find pub cache directory";
   }
-  if (flutterDir == null) {
-    throw "flutter root not found";
-  }
   final pubspecLock = await File(pubspecLockPath).readAsString();
   final pubspec = loadYaml(pubspecLock);
   final packages = pubspec['packages'] as Map;
@@ -51,7 +48,7 @@ Future<Map<String, dynamic>> generateLicenseInfo({required String pubspecLockPat
       outerName: node,
       packageJson: packages[node],
       pubCacheDirPath: pubCacheDir,
-      flutterDir: flutterDir!,
+      flutterDir: flutterDir,
       pubspecLockPath: pubspecLockPath,
     );
 

--- a/packages/dart_pubspec_licenses/lib/src/package.dart
+++ b/packages/dart_pubspec_licenses/lib/src/package.dart
@@ -36,7 +36,7 @@ class Package {
     required String outerName,
     required Map packageJson,
     required String pubCacheDirPath,
-    required String flutterDir,
+    required String? flutterDir,
     required String pubspecLockPath,
   }) async {
     Directory directory;
@@ -52,7 +52,7 @@ class Package {
       final repo = gitRepoName(description['url']);
       final commit = description['resolved-ref'];
       directory = Directory(path.join(pubCacheDirPath, 'git/$repo-$commit', description['path']));
-    } else if (source == 'sdk') {
+    } else if (source == 'sdk' && flutterDir != null) {
       directory = Directory(path.join(flutterDir, 'packages', outerName));
       isSdk = true;
     } else if (source == 'path') {
@@ -65,7 +65,7 @@ class Package {
 
     String? license;
     bool isMarkdown = false;
-    if (outerName == 'flutter') {
+    if (outerName == 'flutter' && flutterDir != null) {
       license = await File(path.join(flutterDir, 'LICENSE')).readAsString();
     } else {
       String licensePath = path.join(directory.path, 'LICENSE');
@@ -96,7 +96,7 @@ class Package {
     }
 
     String? version = yaml['version'];
-    if (outerName == 'flutter') {
+    if (outerName == 'flutter' && flutterDir != null) {
       version = await File(path.join(flutterDir, 'version')).readAsString();
     }
     if (version == null) {

--- a/packages/dart_pubspec_licenses/pubspec.yaml
+++ b/packages/dart_pubspec_licenses/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_pubspec_licenses
 description: A library to make it easy to extract OSS license information from Dart packages using pubspec.yaml
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/espresso3389/flutter_oss_licenses/tree/master/packages/dart_pubspec_licenses
 repository: https://github.com/espresso3389/flutter_oss_licenses
 


### PR DESCRIPTION
Make the `FLUTTER_ROOT` environment variable optional so that
dart_pubspec_licenses can be more easily used for non-Flutter Dart
projects.