### PR TITLE
Replace $ sign for all strings and not only for the ones that don't have a new line. 

### DIFF
--- a/packages/flutter_oss_licenses/bin/generate.dart
+++ b/packages/flutter_oss_licenses/bin/generate.dart
@@ -40,11 +40,12 @@ main(List<String> args) async {
     } else {
       final sb = StringBuffer();
       String toQuotedString(String s) {
+        s = s.replaceAll('\$', '\\\$');
         final quoteCount = "'".allMatches(s).length;
         final doubleQuoteCount = '"'.allMatches(s).length;
         final quote = quoteCount > doubleQuoteCount ? '"' : "'";
         if (!s.contains('\n')) {
-          return quote + s.replaceAll(quote, "\\$quote").replaceAll('\$', '\\\$') + quote;
+          return quote + s.replaceAll(quote, "\\$quote") + quote;
         }
         final q3 = quote * 3;
         return q3 + s.replaceAll(q3, '\\$quote' * 3) + q3;


### PR DESCRIPTION
Moved the `replaceAll('\$', '\\\$')` statement out of the `if (!s.contains('\n'))` so that $s in strings with a `\n` are also escaped.
Theoretically also raw strings could be used for these paragraphs which would save bit of performance I guess.
```dart
        if (!s.contains('\n')) {
          return 'r' + quote + s.replaceAll(quote, "\\$quote").replaceAll('\$', '\\\$') + quote;
        }
        final q3 = quote * 3;
        return 'r' + q3 + s.replaceAll(q3, '\\$quote' * 3) + q3;
```
Tested on the license of syncfusion_flutter_charts package.