### PR TITLE
Add Ignore option

### DIFF
--- a/packages/dart_pubspec_licenses/lib/src/license_info_utils.dart
+++ b/packages/dart_pubspec_licenses/lib/src/license_info_utils.dart
@@ -25,14 +25,16 @@ String? guessPubCacheDir() {
     }
   }
 
-  final homeDir = Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'];
+  final homeDir =
+      Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'];
   if (homeDir != null) {
     return path.join(homeDir, '.pub-cache');
   }
   return null;
 }
 
-Future<AllProjectDependencies> listDependencies({required String pubspecLockPath}) async {
+Future<AllProjectDependencies> listDependencies(
+    {required String pubspecLockPath}) async {
   final pubCacheDir = guessPubCacheDir();
   if (pubCacheDir == null) {
     throw "could not find pub cache directory";
@@ -40,6 +42,8 @@ Future<AllProjectDependencies> listDependencies({required String pubspecLockPath
   final pubspecLock = await File(pubspecLockPath).readAsString();
   final pubspec = loadYaml(pubspecLock);
   final packages = pubspec['packages'] as YamlMap;
+
+  packages.removeWhere((key, value) => ignore.contains(key));
 
   final loadedPackages = await Future.wait(
     packages.keys.map(
@@ -53,8 +57,10 @@ Future<AllProjectDependencies> listDependencies({required String pubspecLockPath
     ),
   );
 
-  final packagesByName = Map.fromEntries(loadedPackages.where((p) => p != null).map((p) => MapEntry(p!.name, p)));
-  final allDeps = packages.entries.fold<Map<String, List<Package>>>({}, (map, e) {
+  final packagesByName = Map.fromEntries(
+      loadedPackages.where((p) => p != null).map((p) => MapEntry(p!.name, p)));
+  final allDeps =
+      packages.entries.fold<Map<String, List<Package>>>({}, (map, e) {
     final package = packagesByName[e.key];
     if (package != null) {
       map.putIfAbsent(e.value['dependency'], () => []).add(package);
@@ -68,8 +74,8 @@ Future<AllProjectDependencies> listDependencies({required String pubspecLockPath
     allDependencies: packagesByName.values.toList(),
   );
   final processed = <String>{};
-  await _createDependencies(
-      processed, projectDependencies, packagesByName, allDeps['direct main'], allDeps['direct dev'], null);
+  await _createDependencies(processed, projectDependencies, packagesByName,
+      allDeps['direct main'], allDeps['direct dev'], null);
   return projectDependencies;
 }
 
@@ -93,23 +99,34 @@ Future<void> _createDependencies(
     final pubspecLock = await File(pubspecYamlPath!).readAsString();
     final pubspec = loadYaml(pubspecLock);
     final dep = pubspec['dependencies'];
-    dependencies ??=
-        dep is YamlMap ? dep.keys.map((e) => packagesByName[e]).where((p) => p != null).cast<Package>().toList() : [];
+    dependencies ??= dep is YamlMap
+        ? dep.keys
+            .map((e) => packagesByName[e])
+            .where((p) => p != null)
+            .cast<Package>()
+            .toList()
+        : [];
     if (projectDependencies is AllProjectDependencies) {
       final devDep = pubspec['dev_dependencies'];
       devDependencies ??= devDep is YamlMap
-          ? devDep.keys.map((e) => packagesByName[e]).where((p) => p != null).cast<Package>().toList()
+          ? devDep.keys
+              .map((e) => packagesByName[e])
+              .where((p) => p != null)
+              .cast<Package>()
+              .toList()
           : [];
     }
   }
 
   for (final dep in dependencies) {
-    await _createDependencies(processed, dep, packagesByName, null, null, dep.pubspecYamlPath);
+    await _createDependencies(
+        processed, dep, packagesByName, null, null, dep.pubspecYamlPath);
   }
   projectDependencies.dependencies.addAll(dependencies);
   if (projectDependencies is AllProjectDependencies) {
     for (final dep in devDependencies!) {
-      await _createDependencies(processed, dep, packagesByName, null, null, dep.pubspecYamlPath);
+      await _createDependencies(
+          processed, dep, packagesByName, null, null, dep.pubspecYamlPath);
     }
     projectDependencies.devDependencies.addAll(devDependencies);
   }

--- a/packages/flutter_oss_licenses/bin/generate.dart
+++ b/packages/flutter_oss_licenses/bin/generate.dart
@@ -28,15 +28,18 @@ main(List<String> args) async {
     }
 
     final projectRoot = results['project-root'] ?? await findProjectRoot();
-    final outputFilePath = results['output'] ?? path.join(projectRoot, 'lib', 'oss_licenses.dart');
-    final generateJson = results['json'] || path.extension(outputFilePath).toLowerCase() == '.json';
+    final outputFilePath =
+        results['output'] ?? path.join(projectRoot, 'lib', 'oss_licenses.dart');
+    final generateJson = results['json'] ||
+        path.extension(outputFilePath).toLowerCase() == '.json';
     final deps = await oss.listDependencies(
       pubspecLockPath: path.join(projectRoot, 'pubspec.lock'),
     );
 
     final String output;
     if (generateJson) {
-      output = const JsonEncoder.withIndent('  ').convert(deps.allDependencies.map((e) => e.toJson()).toList());
+      output = const JsonEncoder.withIndent('  ')
+          .convert(deps.allDependencies.map((e) => e.toJson()).toList());
     } else {
       final sb = StringBuffer();
       String toQuotedString(String s) {
@@ -44,7 +47,9 @@ main(List<String> args) async {
         final doubleQuoteCount = '"'.allMatches(s).length;
         final quote = quoteCount > doubleQuoteCount ? '"' : "'";
         if (!s.contains('\n')) {
-          return quote + s.replaceAll(quote, "\\$quote").replaceAll('\$', '\\\$') + quote;
+          return quote +
+              s.replaceAll(quote, "\\$quote").replaceAll('\$', '\\\$') +
+              quote;
         }
         final q3 = quote * 3;
         return q3 + s.replaceAll(q3, '\\$quote' * 3) + q3;
@@ -84,7 +89,8 @@ main(List<String> args) async {
         writeIfNotNull('license', l.license);
         writeIfNotNull('isMarkdown', l.isMarkdown);
         writeIfNotNull('isSdk', l.isSdk);
-        sb.writeln('    dependencies: [${l.dependencies.map((d) => 'PackageRef(\'${d.name}\')').join(', ')}]');
+        sb.writeln(
+            '    dependencies: [${l.dependencies.map((d) => 'PackageRef(\'${d.name}\')').join(', ')}]');
 
         sb.writeln('  );');
         sb.writeln('');
@@ -186,16 +192,32 @@ The default output file path depends on the --json flag:
   with    --json: PROJECT_ROOT/assets/oss_licenses.json
   without --json: PROJECT_ROOT/lib/oss_licenses.dart
 ''');
+  parser.addMultiOption('ignore',
+      abbr: 'i',
+      defaultsTo: [],
+      splitCommas: true,
+      help: '''Ignore packages by name.
+      This option can be specified multiple times, or as a comma-separated list.
+      --ignore foo,bar is equivalent to --ignore foo --ignore bar
+      ''');
   parser.addOption('project-root',
-      abbr: 'p', defaultsTo: null, help: 'Explicitly specify project root directory that contains pubspec.lock.');
+      abbr: 'p',
+      defaultsTo: null,
+      help:
+          'Explicitly specify project root directory that contains pubspec.lock.');
   parser.addFlag('json',
-      abbr: 'j', defaultsTo: false, negatable: false, help: 'Generate JSON file rather than dart file.');
-  parser.addFlag('help', abbr: 'h', defaultsTo: false, negatable: false, help: 'Show the help.');
+      abbr: 'j',
+      defaultsTo: false,
+      negatable: false,
+      help: 'Generate JSON file rather than dart file.');
+  parser.addFlag('help',
+      abbr: 'h', defaultsTo: false, negatable: false, help: 'Show the help.');
 
   return parser;
 }
 
 void printUsage(ArgParser parser) {
-  stdout.writeln('Usage: ${path.basename(Platform.script.toString())} [OPTION]');
+  stdout
+      .writeln('Usage: ${path.basename(Platform.script.toString())} [OPTION]');
   stdout.writeln(parser.usage);
 }

--- a/packages/flutter_oss_licenses/bin/generate.dart
+++ b/packages/flutter_oss_licenses/bin/generate.dart
@@ -34,6 +34,7 @@ main(List<String> args) async {
         path.extension(outputFilePath).toLowerCase() == '.json';
     final deps = await oss.listDependencies(
       pubspecLockPath: path.join(projectRoot, 'pubspec.lock'),
+      ignore: results['ignore'],
     );
 
     final String output;
@@ -198,7 +199,8 @@ The default output file path depends on the --json flag:
       splitCommas: true,
       help: '''Ignore packages by name.
       This option can be specified multiple times, or as a comma-separated list.
-      --ignore foo,bar is equivalent to --ignore foo --ignore bar
+      `[...] --ignore flutter_oss_licenses,dart_pubspec_licenses` is equivalent to
+      `[...] --ignore flutter_oss_licenses --ignore dart_pubspec_licenses`
       ''');
   parser.addOption('project-root',
       abbr: 'p',

--- a/packages/flutter_oss_licenses/example/pubspec.lock
+++ b/packages/flutter_oss_licenses/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.1"
+    version: "3.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -115,26 +115,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -155,18 +155,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -232,10 +232,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   url_launcher:
     dependency: "direct main"
     description:
@@ -312,10 +312,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.4"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
Added option to ignore specific packages.

Context:
This packages also grabs packages that are defined locally in the project, which you might not want to have in the final generated list.

How to use:
`flutter pub run flutter_oss_licenses:generate.dart --ignore=package_name_1,package_name_2`